### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#iconate.js
+# iconate.js
 *A call to transform your existing icons in a cool trendy way*
 
 `iconate.js` is a tiny performant library for cross-browser icon transformation animations in your projects.
 
-##[Demo](http://bitshadow.github.io/iconate)
+## [Demo](http://bitshadow.github.io/iconate)
 
 Installation
 ------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
